### PR TITLE
Fix menu text misalignment

### DIFF
--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -191,8 +191,10 @@ Item {
 
                 PlasmaComponents.Label{
                     id: buttonLbl
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    verticalAlignment: Text.AlignVCenter
                     anchors.horizontalCenter: parent.horizontalCenter
-                    anchors.verticalCenter: parent.verticalCenter
 
                     text: {
                         var text = activeMenu;


### PR DESCRIPTION
Similar solution to https://github.com/psifidotos/applet-window-title/pull/16 from https://phabricator.kde.org/R884:1119c47f1756be9d302327f51c31f25e0f4d4e56

Before change:
![globalcomparebefore](https://user-images.githubusercontent.com/16624211/48660832-74417c00-eabc-11e8-91e6-0b83f1c2c4e2.png)

After change:
![globalcompareafter](https://user-images.githubusercontent.com/16624211/48660833-77d50300-eabc-11e8-9616-1dcb1ce8aa08.png)
