### PR TITLE
Add openSUSE to Installation guide

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -12,6 +12,12 @@ Installation
 sudo apt install make cmake extra-cmake-modules qtdeclarative5-dev libkf5plasma-dev libqt5x11extras5-dev g++ libsm-dev
 ```
 
+### openSUSE Leap 15 / Tumbleweed
+
+```
+sudo zypper in -y xrandr cmake make gcc gcc-c++ extra-cmake-modules libqt5-qtbase-devel libqt5-qtdeclarative-devel libKF5WindowSystem5 plasma-framework-devel libSM-devel libqt5-qtx11extras-devel
+```
+
 ### Building and Installing
 
 **Now you can run the installation script.**


### PR DESCRIPTION
Hi, 

I noticed that #61 was about installing on openSUSE and that no installation directions were written for Tumbleweed / Leap yet. Since I personally also use openSUSE, it was only a small effort to add this. Tested by pulling the base Tumbleweed & Leap images from the docker hub and compiling the applet on those.