### PR TITLE
Fix compiler warning, improve installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@ if ! [ -a build ] ; then
     mkdir build
 fi
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr .. -Wnodev
-make
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release  .. -Wnodev
+make -j$(nproc)
 sudo make install

--- a/plugin/appmenumodel.cpp
+++ b/plugin/appmenumodel.cpp
@@ -417,7 +417,7 @@ QVariant AppMenuModel::data(const QModelIndex &index, int role) const
     if (role == MenuRole) { // TODO this should be Qt::DisplayRole
         return actions.at(row)->text();
     } else if (role == ActionRole) {
-        return qVariantFromValue((void *) actions.at(row));
+        return QVariant::fromValue((void *) actions.at(row));
     }
 
     return QVariant();


### PR DESCRIPTION
The warning `QVariant qVariantFromValue(const T&) [with T = void*]’ is deprecated: Use QVariant::fromValue() instead` has been fixed.

Additionally when compiling the files the installer uses all available cores and the build type is now specified. Before this the installer would generate a debug build, which is not optimized and and bigger (release build is upper one):  
![size_comparison](https://user-images.githubusercontent.com/38406607/75100695-8d937b00-55d1-11ea-93b1-0dffe741aa2c.png)

By the way: Have you considered creating binary packages (for instance deb/rpm), this could make it easier to install, especially for beginners.

And thanks for this project 😄. 